### PR TITLE
Refactored code to handle server errors when pulling reports from KM

### DIFF
--- a/R/kiss-reports.R
+++ b/R/kiss-reports.R
@@ -39,20 +39,7 @@ KissReports <- function() {
 #' @export
 read.KissReports <- function(reports) {
   # Make request
-  headers <- c(authorizationHeader(), jsonHeader())
-  body <- ""
-  encoding <- "json"
-
-  requestKey <- c(reports$url, headers, body, encoding)
-  response <- readCache(reports, requestKey)
-  if (is.null(response)) {
-    response <- httr::GET(reports$url,
-                           encode = encoding,
-                           httr::add_headers(.headers = headers))
-
-    httr::stop_for_status(response)
-    writeCache(reports, requestKey, response)
-  }
+  response <- readUrl(reports$url, reports)
 
   # Get list of reports
   links  <- jsonlite::fromJSON(httr::content(response, "text"))$links


### PR DESCRIPTION
Changed default report items per page to 1000 from 50.
Added a psuedo-progress bar
Refactored the URL reading logic into a new readUrl function
