### PR TITLE
BI-1101 - people-search-v3 support

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,9 +1,10 @@
 Package: kissr
 Title: Load Data From Kiss Metrics People Reports
-Version: 0.0.1.2
+Version: 1.0.0.0
 Authors@R: person("Yosem", "Sweet", email = "yosem.sweet@unbounce.com", role = c("aut", "cre"))
-Description: Kissr provides an interface to Kiss Metrics Core API, allowing you to query any prebuilt
-    People Reports and hiding the complexities of pagination and waiting for the report to run.
+Description: Kissr provides an interface to Kiss Metrics Core API, allowing you
+    to use the new people_search_v3 API. It hides hiding the complexities of
+    pagination and waiting for the report to run.
 Depends: R (>= 3.1.2)
 License: MIT
 LazyData: true

--- a/R/asJson.R
+++ b/R/asJson.R
@@ -1,0 +1,17 @@
+#' asJson s3 generic
+#'
+#' This is a generic function that dispatches to the specific asJson
+#' implementation. For instance \link{asJson.KissReport} or
+#' \link{asJson.KissRule}
+#'
+#' @export
+asJson <- function(object, ...) {
+  UseMethod("asJson", object)
+}
+
+#' Default asJson implementation - by default we just call jsonlite::toJSON
+#' @export
+asJson.default <- function(object, ...) {
+  jsonlite::toJSON(object)
+}
+

--- a/R/kiss-attributes.R
+++ b/R/kiss-attributes.R
@@ -1,15 +1,8 @@
-# Attribute (Event and Property) Explorer Functions
-
-# Use GetAttributeList() to get full list of properties and events from KM
-# Example: attributesList <- GetAttributeList()
-
-# Use GetAttributeIndex() by feeding it a single event/property Display Name to
-# get the corresponding index to be used with KissReports
-# Example: contactCreatedIndex <- GetAttributeIndex("Contact created")
-
-# Outputs full list of KM events and properties as a df
-# No parameters needed
-
+#' Attribute (Event and Property) Explorer Functions
+#'
+#' Use GetAttributeList() to get full list of properties and events from KM
+#' @example
+#' attributesList <- GetAttributeList()
 GetAttributeList <- function(){
   # Get list of events from KM
   eventsList <- read(KissEvents())
@@ -22,15 +15,16 @@ GetAttributeList <- function(){
 
   return(fullAttributeList)
 }
-
-# Outputs event/property index used as paramenter in KissReport function
+#'
+#' Outputs event/property index used as paramenter in KissReport function
+#' @example
+#' contactCreatedIndex <- GetAttributeIndex("Contact created")
 GetAttributeIndex <- function(attributeName,
                               productId = "6581c29e-ab13-1030-97f2-22000a91b1a1"){
   fullAttributeList <- GetAttributeList()
 
   attributeIndex <- dplyr::filter(fullAttributeList, display_name == attributeName &
                              product_id == productId)
-
   if(nrow(attributeIndex) == 1){
     attributeIndex <- as.numeric(attributeIndex$index)
     return(attributeIndex)
@@ -43,8 +37,10 @@ GetAttributeIndex <- function(attributeName,
                 "for full list of attributes (display_name column)."))
   }
 }
-
-# Output event/property name from index number
+#'
+#' Output event/property name from index number as data frame
+#' @example
+#' contactCreatedIndex <- GetAttributeName(6)
 GetAttributeName <- function(attributeIndex,
                               productId = "6581c29e-ab13-1030-97f2-22000a91b1a1"){
   fullAttributeList <- GetAttributeList()

--- a/R/kiss-attributes.R
+++ b/R/kiss-attributes.R
@@ -1,0 +1,66 @@
+# Attribute (Event and Property) Explorer Functions
+
+# Use GetAttributeList() to get full list of properties and events from KM
+# Example: attributesList <- GetAttributeList()
+
+# Use GetAttributeIndex() by feeding it a single event/property Display Name to
+# get the corresponding index to be used with KissReports
+# Example: contactCreatedIndex <- GetAttributeIndex("Contact created")
+
+# Outputs full list of KM events and properties as a df
+# No parameters needed
+
+GetAttributeList <- function(){
+  # Get list of events from KM
+  eventsList <- read(KissEvents())
+  eventsList$metric_type <- "event"
+  # Get list of properties from KM
+  propertiesList <- read(KissProperties())
+  propertiesList$metric_type <- "property"
+  # Union both tables
+  fullAttributeList <- rbind(eventsList,propertiesList)
+
+  return(fullAttributeList)
+}
+
+# Outputs event/property index used as paramenter in KissReport function
+GetAttributeIndex <- function(attributeName,
+                              productId = "6581c29e-ab13-1030-97f2-22000a91b1a1"){
+  fullAttributeList <- GetAttributeList()
+
+  attributeIndex <- filter(fullAttributeList, display_name == attributeName &
+                             product_id == productId)
+
+  if(nrow(attributeIndex) == 1){
+    attributeIndex <- as.numeric(attributeIndex$index)
+    return(attributeIndex)
+  } else if (nrow(attributeIndex) > 1){
+    stop(paste0("More than one attribute with that name.\n",
+                "Use GetAttributeList() for full list of attributes  (display_name column)."))
+  } else {
+    stop(paste0("Attribute name not in table.\n",
+                "Check attribute spelling by using GetAttributeList()\n",
+                "for full list of attributes (display_name column)."))
+  }
+}
+
+# Output event/property name from index number
+GetAttributeName <- function(attributeIndex,
+                              productId = "6581c29e-ab13-1030-97f2-22000a91b1a1",
+                             metricType = "event"){
+  fullAttributeList <- GetAttributeList()
+  metricType <- metricType
+  attributeName <- filter(fullAttributeList,index == attributeIndex &
+                            product_id == productId &
+                            metric_type == metricType)
+
+  if(nrow(attributeName) == 1){
+    return(attributeName$"name")
+  } else if(nrow(attributeName) > 1) {
+    stop(paste0("More than one attribute with that index.\n",
+                "Use GetAttributeList() for full list of attributes (index column)."))
+  } else {
+    stop(paste0("Attribute index not in table.\n",
+                "Check full attribute list by using GetAttributeList()."))
+  }
+}

--- a/R/kiss-attributes.R
+++ b/R/kiss-attributes.R
@@ -28,7 +28,7 @@ GetAttributeIndex <- function(attributeName,
                               productId = "6581c29e-ab13-1030-97f2-22000a91b1a1"){
   fullAttributeList <- GetAttributeList()
 
-  attributeIndex <- filter(fullAttributeList, display_name == attributeName &
+  attributeIndex <- dplyr::filter(fullAttributeList, display_name == attributeName &
                              product_id == productId)
 
   if(nrow(attributeIndex) == 1){
@@ -46,19 +46,13 @@ GetAttributeIndex <- function(attributeName,
 
 # Output event/property name from index number
 GetAttributeName <- function(attributeIndex,
-                              productId = "6581c29e-ab13-1030-97f2-22000a91b1a1",
-                             metricType = "event"){
+                              productId = "6581c29e-ab13-1030-97f2-22000a91b1a1"){
   fullAttributeList <- GetAttributeList()
-  metricType <- metricType
-  attributeName <- filter(fullAttributeList,index == attributeIndex &
-                            product_id == productId &
-                            metric_type == metricType)
+  attributeName <- dplyr::filter(fullAttributeList,index == attributeIndex &
+                            product_id == productId)
 
-  if(nrow(attributeName) == 1){
-    return(attributeName$"name")
-  } else if(nrow(attributeName) > 1) {
-    stop(paste0("More than one attribute with that index.\n",
-                "Use GetAttributeList() for full list of attributes (index column)."))
+  if(nrow(attributeName) >= 1){
+    return(attributeName[,c("display_name","metric_type")])
   } else {
     stop(paste0("Attribute index not in table.\n",
                 "Check full attribute list by using GetAttributeList()."))

--- a/R/kiss-calculation.R
+++ b/R/kiss-calculation.R
@@ -47,10 +47,9 @@ KissCalculation.Event <- function(label,
                                   frequencyValue = 1,
                                   frequencyOccurance = 'at_least',
                                   negate = FALSE) {
-  options <- c()
-  if(!is.na(interval)) {
-    options <- c(defaultDateRange = interval)
-  }
+
+  if (!lubridate::is.interval(interval))
+    stop("interval must be a valid interval")
 
   structure(list(
     type = type,
@@ -60,8 +59,7 @@ KissCalculation.Event <- function(label,
       event = eventId,
       frequencyValue = frequencyValue,
       frequencyOccurance = frequencyOccurance,
-      version = 2,
-      options = options),
+      dateRange = makeKMDateRange(interval)),
     label = label),
     class = c("KissCalculation.Event", "KissCalculation"))
 }
@@ -113,10 +111,9 @@ KissCalculation.Property <- function(label,
                                      interval = NA,
                                      comparisonMode = 'any_value',
                                      negate = FALSE) {
-  options <- c()
-  if(!is.na(interval)) {
-    options <- c(defaultDateRange = interval)
-  }
+
+  if (!lubridate::is.interval(interval))
+    stop("interval must be a valid interval")
 
   structure(list(
     type = type,
@@ -125,8 +122,7 @@ KissCalculation.Property <- function(label,
       negate = negate,
       property = propertyId,
       comparisonMode = comparisonMode,
-      version = 2,
-      options = options),
+      dateRange = makeKMDateRange(interval)),
     label = label),
     class = c("KissCalculation.Property", "KissCalculation"))
 }

--- a/R/kiss-calculation.R
+++ b/R/kiss-calculation.R
@@ -17,19 +17,21 @@
 #' @param negate Unclear what this does - defaults to \code{FALSE}
 #'
 #' @examples
-#'    firstTimeVisitedCalculation <- KissCalculation.Event(
-#'                      label = "First time of visited site",
-#'                      eventId = 6,
-#'                      type = "first_date_in_range")
-#'    lastTimeVisitedCalculation <- KissCalculation.Event(
-#'                      label = "Last time of visited site",
-#'                      eventId = 6,
-#'                      type = "last_date_in_range")
 #'    reportDates <- lubridate::interval(as.Date("2015-06-01"), as.Date("2015-06-02"))
 #'    rules <- list(KissRule.Event(FALSE, 72, 1, "at_least", "any_value"))
 #'    segment <- KissSegment(type = "and",
 #'                 rules = rules,
 #'                 defaultInterval = reportDates)
+#'    firstTimeVisitedCalculation <- KissCalculation.Event(
+#'                      label = "First time of visited site",
+#'                      eventId = 6,
+#'                      type = "first_date_in_range",
+#'                      interval = reportDates)
+#'    lastTimeVisitedCalculation <- KissCalculation.Event(
+#'                      label = "Last time of visited site",
+#'                      eventId = 6,
+#'                      type = "last_date_in_range",
+#'                      interval = reportDates)
 #'    report <- KissReport(productId = "6581c29e-ab13-1030-97f2-22000a91b1a1",
 #'                 segment = segment,
 #'                 calculations = list(
@@ -81,15 +83,17 @@ KissCalculation.Event <- function(label,
 #' @param negate Unclear what this does - defaults to \code{FALSE}
 #'
 #' @examples
+#'    reportDates <- lubridate::interval(as.Date("2015-06-01"), as.Date("2015-06-02"))
 #'    firstCampaignSourceCalculation <- KissCalculation.Property(
 #'                      label = "First campaign source",
 #'                      propertyId = 7,
-#'                      type = "first_value_in_range")
+#'                      type = "first_value_in_range",
+#'                      interval = reportDates)
 #'    lastCampaignSourceCalculation <- KissCalculation.Property(
 #'                      label = "Last campaign source",
 #'                      propertyId = 7,
-#'                      type = "last_value_in_range")
-#'    reportDates <- lubridate::interval(as.Date("2015-06-01"), as.Date("2015-06-02"))
+#'                      type = "last_value_in_range",
+#'                      interval = reportDates)
 #'    rules <- list(KissRule.Event(FALSE, 72, 1, "at_least", "any_value"))
 #'    segment <- KissSegment(type = "and",
 #'                 rules = rules,

--- a/R/kiss-calculation.R
+++ b/R/kiss-calculation.R
@@ -1,0 +1,140 @@
+#' A \code{KissCalculation} represents a column for a report. To create a
+#' calculation you need to know if you want the column to represent a value of
+#' an event or of a property. \code{KissCalculation.Event} should be used
+#' when you are generating a report that shows the first time, last time, or
+#' total times an event has occured
+#' @param eventId Which event are you calculating on. We need the index or id.
+#' @param label The column name in the final report results.
+#' @parma type What sort of calculation do you want to make? For a
+#'   \code{KissCalculation.Event} you have the following options:
+#'   \code{first_date_in_range}, \code{last_date_in_range},
+#'   \code{total_times_in_range}.
+#' @param frequencyValue - unclear what this does - defaults to \code{1}
+#' @param frequencyOccurance - unclear what this does - defaults to
+#'   \code{'at_least'}
+#' @param interval What time frame are we looking at the events over? Defaults
+#'   to NA which uses the overall report time frame
+#' @param negate Unclear what this does - defaults to \code{FALSE}
+#'
+#' @examples
+#'    firstTimeVisitedCalculation <- KissCalculation.Event(
+#'                      label = "First time of visited site",
+#'                      eventId = 6,
+#'                      type = "first_date_in_range")
+#'    lastTimeVisitedCalculation <- KissCalculation.Event(
+#'                      label = "Last time of visited site",
+#'                      eventId = 6,
+#'                      type = "last_date_in_range")
+#'    reportDates <- lubridate::interval(as.Date("2015-06-01"), as.Date("2015-06-02"))
+#'    rules <- list(KissRule.Event(FALSE, 72, 1, "at_least", "any_value"))
+#'    segment <- KissSegment(type = "and",
+#'                 rules = rules,
+#'                 defaultInterval = reportDates)
+#'    report <- KissReport(productId = "6581c29e-ab13-1030-97f2-22000a91b1a1",
+#'                 segment = segment,
+#'                 calculations = list(
+#'                   firstTimeVisitedCalculation,
+#'                   lastTimeVisitedCalculation
+#'                 ),
+#'                 interval = reportDates
+#'              )
+#'    reportResults <- read(report)
+#' @export
+KissCalculation.Event <- function(label,
+                                  eventId,
+                                  type,
+                                  interval = NA,
+                                  frequencyValue = 1,
+                                  frequencyOccurance = 'at_least',
+                                  negate = FALSE) {
+  options <- c()
+  if(!is.na(interval)) {
+    options <- c(defaultDateRange = interval)
+  }
+
+  structure(list(
+    type = type,
+    subject = list(
+      type = "event",
+      negate = negate,
+      event = eventId,
+      frequencyValue = frequencyValue,
+      frequencyOccurance = frequencyOccurance,
+      version = 2,
+      options = options),
+    label = label),
+    class = c("KissCalculation.Event", "KissCalculation"))
+}
+
+#' A \code{KissCalculation} represents a column for a report. To create a
+#' calculation you need to know if you want the column to represent a value of
+#' an event or of a property.
+#' @param propertyId Which property are you calculating on. We need the index or
+#'   id.
+#' @param label The column name in the final report results.
+#' @parma type What sort of calculation do you want to make? For a
+#'   \code{KissCalculation.Property} you have the following options:
+#'   \code{first_date_in_range}, \code{last_date_in_range},
+#'   \code{first_value_in_range}, \code{last_value_in_range}.
+#' @param comparisonMode - unclear what this does - defaults to
+#'   \code{'any_value'}
+#' @param interval What time frame are we looking at the events over? Defaults
+#'   to NA which uses the overall report time frame
+#' @param negate Unclear what this does - defaults to \code{FALSE}
+#'
+#' @examples
+#'    firstCampaignSourceCalculation <- KissCalculation.Property(
+#'                      label = "First campaign source",
+#'                      propertyId = 7,
+#'                      type = "first_value_in_range")
+#'    lastCampaignSourceCalculation <- KissCalculation.Property(
+#'                      label = "Last campaign source",
+#'                      propertyId = 7,
+#'                      type = "last_value_in_range")
+#'    reportDates <- lubridate::interval(as.Date("2015-06-01"), as.Date("2015-06-02"))
+#'    rules <- list(KissRule.Event(FALSE, 72, 1, "at_least", "any_value"))
+#'    segment <- KissSegment(type = "and",
+#'                 rules = rules,
+#'                 defaultInterval = reportDates)
+#'    report <- KissReport(productId = "6581c29e-ab13-1030-97f2-22000a91b1a1",
+#'                 segment = segment,
+#'                 calculations = list(
+#'                   firstCampaignSourceCalculation,
+#'                   lastCampaignSourceCalculation
+#'                 ),
+#'                 interval = reportDates
+#'              )
+#'    reportResults <- read(report)
+#'
+#' @export
+KissCalculation.Property <- function(label,
+                                     propertyId,
+                                     type,
+                                     interval = NA,
+                                     comparisonMode = 'any_value',
+                                     negate = FALSE) {
+  options <- c()
+  if(!is.na(interval)) {
+    options <- c(defaultDateRange = interval)
+  }
+
+  structure(list(
+    type = type,
+    subject = list(
+      type = "property",
+      negate = negate,
+      property = propertyId,
+      comparisonMode = comparisonMode,
+      version = 2,
+      options = options),
+    label = label),
+    class = c("KissCalculation.Property", "KissCalculation"))
+}
+
+#' Convert a KissCalculation into a json structure understood by the KM API.
+#' @export
+asJson.KissCalculation <- function(calculation) {
+  json <- jsonlite::toJSON(c(calculation), auto_unbox=TRUE)
+  return(json)
+}
+

--- a/R/kiss-events.R
+++ b/R/kiss-events.R
@@ -1,0 +1,37 @@
+# KissEvents
+
+# Used to get list of events table from Kissmetrics
+# Example: listEvents <- read(KissEvents())
+# Also used to separate functions to easily access attributes
+# See: attribute-explorers.R
+
+KissEvents <- function() {
+  url <- httr::parse_url("https://api.kissmetrics.com/core/events")
+
+  structure(list(
+    url = url),
+    class = "KissEvents")
+}
+
+
+#' Read a list of events from a KissEvents object
+#'
+#' This function reads all the data from a KissMetrics events table
+#' returning the index,product_id,name, and display_name columns in a data frame.
+#'
+#'
+read.KissEvents <- function(events) {
+  # Make request
+  response <- readUrl(events$url, events)
+
+  # Get list of reports
+  links  <- jsonlite::fromJSON(httr::content(response, "text"))$links
+
+  eventsLink <- links[links$name == "First", "href"]
+  print("Getting all events")
+  results <- as.data.frame(loadPages(events, eventsLink), stringsAsFactors = FALSE)
+
+  # We only need a few columns from the generated table
+  results <- results[,c("index","product_id","name", "display_name")]
+  results
+}

--- a/R/kiss-properties.R
+++ b/R/kiss-properties.R
@@ -1,0 +1,37 @@
+# KissProperties
+
+# Used to get list of properties table from Kissmetrics
+# Example: listProperties <- read(KissProperties())
+# Also used to separate functions to easily access attributes
+# See: attribute-explorers.R
+
+KissProperties <- function() {
+  url <- httr::parse_url("https://api.kissmetrics.com/core/properties")
+
+  structure(list(
+    url = url),
+    class = "KissProperties")
+}
+
+
+#' Read a list of properties from a KissProperties object
+#'
+#' This function reads all the data from a KissMetrics properties table
+#' returning the index,product_id,name, and display_name columns in a data frame.
+#'
+
+read.KissProperties <- function(properties) {
+  # Make request
+  response <- readUrl(properties$url, properties)
+
+  # Get list of reports
+  links  <- jsonlite::fromJSON(httr::content(response, "text"))$links
+
+  propertiesLink <- links[links$name == "First", "href"]
+  print("Getting all properties")
+  results <- as.data.frame(loadPages(properties, propertiesLink), stringsAsFactors = FALSE)
+
+  # We only need a few columns from the generated table
+  results <- results[,c("index","product_id","name", "display_name")]
+  results
+}

--- a/R/kiss-report.R
+++ b/R/kiss-report.R
@@ -20,7 +20,8 @@
 #'   be passed to the read S3 generic
 #' @examples
 #'    reportDates <- lubridate::interval(as.Date("2015-06-01"), as.Date("2015-06-02"))
-#'    rules <- list(KissRule.Event(FALSE, 72, 1, "at_least", "any_value"))
+#'    rules <- list(KissRule.Event(FALSE, 72, 1, "at_least", "any_value",
+#'                                interval = reportDates))
 #'    segment <- KissSegment(type = "and",
 #'                 rules = rules,
 #'                 defaultInterval = reportDates)
@@ -30,7 +31,6 @@
 #'                   KissCalculation.Event(label = "First time of visited site",
 #'                      eventId = 6,
 #'                      type = "first_date_in_range",
-#'                      negate = FALSE,
 #'                      frequencyValue = 1,
 #'                      frequencyOccurance = "at_least")),
 #'                 interval = reportDates
@@ -165,8 +165,12 @@ read.KissReport <- function(report) {
   convertTime <- function(x) {
     timeVariable <- as.POSIXct(as.numeric(x), origin = "1970-01-01", tz = "UTC")
     # Correct timezone to UTC
+    systemTimezone <- Sys.getenv("KISSR__KISSMETRICS_CONFIGURED_TIMEZONE_ZONENAME")
+    if(systemTimezone == "") {
+      systemTimezone <- "UTC"
+    }
     timeVariable <- as.POSIXct(as.character(timeVariable),
-                               Sys.getenv("KISSR__KISSMETRICS_CONFIGURED_TIMEZONE_ZONENAME"))
+                               systemTimezone)
     attr(timeVariable,"tzone") <- "UTC"
     timeVariable
   }

--- a/R/kiss-report.R
+++ b/R/kiss-report.R
@@ -158,11 +158,17 @@ read.KissReport <- function(report) {
     names(results) <- names(report)
   }
 
-  # KissMetrics returns times as unix timestamps (seconds from origin in UTC)
+  # KissMetrics returns times as unix timestamps. However seconds are
+  # from timezone set within KissMetrics Product Info (not necessarily UTC)
   # Update every column generated from a calculation with type matching *_date_*
   # to be POSIX.ct time.
   convertTime <- function(x) {
-    as.POSIXct(as.numeric(x), origin = "1970-01-01", tz = "UTC")
+    timeVariable <- as.POSIXct(as.numeric(x), origin = "1970-01-01", tz = "UTC")
+    # Correct timezone to UTC
+    timeVariable <- as.POSIXct(as.character(timeVariable),
+                               Sys.getenv("KISSR__KISSMETRICS_CONFIGURED_TIMEZONE_ZONENAME"))
+    attr(timeVariable,"tzone") <- "UTC"
+    timeVariable
   }
   results <- dplyr::mutate_each(results,
                                 dplyr::funs(convertTime),

--- a/R/kiss-rule.R
+++ b/R/kiss-rule.R
@@ -36,7 +36,7 @@
 #' @export
 KissRule.Event <- function(negate, eventId, frequencyValue, frequencyOccurance,
                            interval = NA, comparisonMode = 'any_value') {
-  if (!lubridate::is.interval(interval) & !is.na(interval))
+  if (!lubridate::is.interval(interval))
     stop("interval must be a valid interval")
   structure(list(
     type = "event",

--- a/R/kiss-rule.R
+++ b/R/kiss-rule.R
@@ -1,0 +1,169 @@
+#' \code{KissRule.Event} objects are used to define target segments to run a report on.
+#' @param eventId Which event are you targeting on? We need the index or id.
+#' @param frequencyValue How many times the event needs to have happened for the
+#'   rule
+#' @param frequencyOccurance How we are comparing against the
+#'   \code{frequencyValue}. Must be \code{at_least}, \code{at_most}, or
+#'   \code{exactly}
+#' @param interval What time frame are we looking at the events over? Defaults
+#'   to NA which uses the overall report time frame
+#' @param comparisonMode - unclear what this does. Defaults to 'any_value'
+#' @param negate Is this an inclusive rule or an exclusionary rule?
+#'
+#' @examples
+#'    firstTimeVisitedCalculation <- KissCalculation.Event(
+#'                      label = "First time of visited site",
+#'                      eventId = 6,
+#'                      type = "first_date_in_range")
+#'    lastTimeVisitedCalculation <- KissCalculation.Event(
+#'                      label = "Last time of visited site",
+#'                      eventId = 6,
+#'                      type = "last_date_in_range")
+#'    reportDates <- lubridate::interval(as.Date("2015-06-01"), as.Date("2015-06-02"))
+#'    rules <- list(KissRule.Event(FALSE, 72, 1, "at_least", "any_value"))
+#'    segment <- KissSegment(type = "and",
+#'                 rules = rules,
+#'                 defaultInterval = reportDates)
+#'    report <- KissReport(productId = "6581c29e-ab13-1030-97f2-22000a91b1a1",
+#'                 segment = segment,
+#'                 calculations = list(
+#'                   firstTimeVisitedCalculation,
+#'                   lastTimeVisitedCalculation
+#'                 ),
+#'                 interval = reportDates
+#'              )
+#'    reportResults <- read(report)
+#' @export
+KissRule.Event <- function(negate, eventId, frequencyValue, frequencyOccurance,
+                           interval = NA, comparisonMode = 'any_value') {
+  if (!lubridate::is.interval(interval) & !is.na(interval))
+    stop("interval must be a valid interval")
+  structure(list(
+    type = "event",
+    negate = negate,
+    event = eventId,
+    frequencyValue = frequencyValue,
+    frequencyOccurance = frequencyOccurance,
+    comparisonMode = comparisonMode,
+    interval = interval),
+    class = c("KissRule.Event", "KissRule"))
+}
+
+#' \code{KissRule.Property} objects are used to define target segments to run a
+#' report on.
+#' @param propertyId Which property are you targeting? We need the index or id.
+#' @param comparisonMode How are we comparing the property? Can be any of
+#'    \code{any_value}, \code{empty}, \code{equals}, \code{contains},
+#'    \code{begins_with}, \code{ends_with}
+#' @param comparisonString What should we compare against? Only used if
+#'    \code{comparisonMode} is \code{equals}, \code{contains},
+#'    \code{begins_with}, or \code{ends_with}
+#' @param interval What time frame are we looking at the properties over?
+#'   Defaults to NA which uses the overall report time frame
+#' @param negate Is this an inclusive rule or an exclusionary rule?
+#'
+#' @examples
+#'    firstTimeVisitedCalculation <- KissCalculation.Event(
+#'                      label = "First time of visited site",
+#'                      eventId = 6,
+#'                      type = "first_date_in_range")
+#'    lastTimeVisitedCalculation <- KissCalculation.Event(
+#'                      label = "Last time of visited site",
+#'                      eventId = 6,
+#'                      type = "last_date_in_range")
+#'    reportDates <- lubridate::interval(as.Date("2015-06-01"), as.Date("2015-06-02"))
+#'    rules <- list(KissRule.Property(negate = FALSE, propertyId = 10, comparisonMode = "any_value", interval = reportDates),
+#'                  KissRule.Property(negate = FALSE, propertyId = 2, comparisonMode = "contains", comparisonString = "copywriting", interval = reportDates))
+#'    segment <- KissSegment(type = "and",
+#'                 rules = rules,
+#'                 defaultInterval = reportDates)
+#'    report <- KissReport(productId = "6581c29e-ab13-1030-97f2-22000a91b1a1",
+#'                 segment = segment,
+#'                 calculations = list(
+#'                   firstTimeVisitedCalculation,
+#'                   lastTimeVisitedCalculation
+#'                 ),
+#'                 interval = reportDates
+#'              )
+#'    reportResults <- read(report)
+#' @export
+KissRule.Property <- function(negate, propertyId, comparisonMode, comparisonString = NA, interval = NA) {
+  property <- list(
+    type = "property",
+    negate = negate,
+    property = propertyId,
+    comparisonMode = comparisonMode,
+    interval = interval)
+  if(comparisonMode %in% c("equals", "contains", "begins_with", "ends_with")) {
+    if(is.na(comparisonString)) stop("You must provide a comparison string for KissRule.Property comparison modes of 'equals', 'contains', 'begins_with', 'ends_with'")
+    property["comparisonString"] <- comparisonString
+  }
+  structure(property,
+    class = c("KissRule.Property", "KissRule"))
+}
+
+#' Generates json for a KissRule.
+#' @export
+asJson.KissRule.Event <- function(rule) {
+  template <- '
+  {
+    "type":"{{type}}",
+    "negate": {{negate}},
+    "event":{{event}},
+    "frequencyValue":"{{frequencyValue}}",
+    "frequencyOccurance":"{{frequencyOccurance}}",
+    "comparisonMode":"{{comparisonMode}}",
+    "dateRange":{{dateRange}}
+  }
+  '
+
+  if (!lubridate::is.interval(rule$interval))
+    stop("rule must have a valid interval")
+
+  json <- template
+  json <- replacePlaceholder(json, "\\{\\{type\\}\\}", rule$type)
+  json <- replacePlaceholder(json, "\\{\\{negate\\}\\}", tolower(rule$negate))
+  json <- replacePlaceholder(json, "\\{\\{event\\}\\}",rule$event)
+  json <- replacePlaceholder(json, "\\{\\{frequencyValue\\}\\}", rule$frequencyValue)
+  json <- replacePlaceholder(json, "\\{\\{frequencyOccurance\\}\\}", rule$frequencyOccurance)
+  json <- replacePlaceholder(json, "\\{\\{comparisonMode\\}\\}", rule$comparisonMode)
+  json <- replacePlaceholder(json, "\\{\\{dateRange\\}\\}",
+                               jsonlite::toJSON(makeKMDateRange(rule$interval),
+                                                auto_unbox = TRUE))
+
+  json
+}
+
+asJson.KissRule.Property <- function(rule) {
+  template <- '
+  {
+  "type":"{{type}}",
+  "negate": {{negate}},
+  "property":{{property}},
+  "comparisonMode":"{{comparisonMode}}",
+  "dateRange":{{dateRange}}{{comparison}}
+  }
+  '
+
+  if (!lubridate::is.interval(rule$interval))
+    stop("rule must have a valid interval")
+
+  json <- template
+  json <- replacePlaceholder(json, "\\{\\{type\\}\\}", rule$type)
+  json <- replacePlaceholder(json, "\\{\\{negate\\}\\}", tolower(rule$negate))
+  json <- replacePlaceholder(json, "\\{\\{property\\}\\}",rule$property)
+  json <- replacePlaceholder(json, "\\{\\{comparisonMode\\}\\}", rule$comparisonMode)
+  if(rule$comparisonMode %in% c("equals", "contains", "begins_with", "ends_with")) {
+    json <- replacePlaceholder(json,"\\{\\{comparison\\}\\}",
+                               paste0(',\n',
+                                      '\"comparisonString\": \"',
+                                      rule$comparisonString,
+                                      '\"'))
+  } else {
+    json <- replacePlaceholder(json,"\\{\\{comparison\\}\\}","")
+  }
+  json <- replacePlaceholder(json, "\\{\\{dateRange\\}\\}",
+                             jsonlite::toJSON(makeKMDateRange(rule$interval),
+                                              auto_unbox = TRUE))
+  json
+}

--- a/R/kiss-rule.R
+++ b/R/kiss-rule.R
@@ -110,7 +110,7 @@ asJson.KissRule.Event <- function(rule) {
     "type":"{{type}}",
     "negate": {{negate}},
     "event":{{event}},
-    "frequencyValue":"{{frequencyValue}}",
+    "frequencyValue":{{frequencyValue}},
     "frequencyOccurance":"{{frequencyOccurance}}",
     "comparisonMode":"{{comparisonMode}}",
     "dateRange":{{dateRange}}

--- a/R/kiss-segment.R
+++ b/R/kiss-segment.R
@@ -1,0 +1,43 @@
+#' Create a new KissSegment
+#'
+#' \code{KissSegment} creates a new S3 object of with class "KissSegment"
+#'
+#' This is a constructor function.
+#' @examples
+#'  rules <- list(KissRule.Event(FALSE, 72, 1, "at_least", "any_value"))
+#'  segment <- KissSegment(type = "and",
+#'                         rules = rules,
+#'                         defaultInterval = lubridate::interval(as.Date("2015-06-01"), as.Date("2015-06-02")))
+#'
+#' @param type 'and' or 'or' - how should the rules for the segment be combined
+#' @export
+KissSegment <- function(type, rules, defaultInterval = NA) {
+  options <- c()
+  if(!is.na(defaultInterval)) {
+    rules <- lapply(rules, function(r) {
+        if(is.na(r$interval)) r$interval <- defaultInterval
+        r
+      })
+  }
+
+  segment <- structure(list(
+    type = type,
+    rules = rules,
+    options = options),
+    class = "KissSegment")
+}
+
+
+#' @export
+asJson.KissSegment <- function(segment) {
+  segmentTemplate <- '{"type":"{{type}}", "operands":[{{rules}}], "options": {{options}}}'
+
+  json <- segmentTemplate
+  json <- replacePlaceholder(json, "\\{\\{type\\}\\}", segment$type)
+  rulesJson <- lapply(segment$rules, asJson)
+  json <- replacePlaceholder(json, "\\{\\{rules\\}\\}", paste(rulesJson, collapse=","))
+  json <- replacePlaceholder(json,
+                             "\\{\\{options\\}\\}",
+                             jsonlite::toJSON(lapply(segment$options, as.list), auto_unbox=TRUE))
+  return(json)
+}

--- a/km_docs/sample-curl-peoplesearchv3.bash
+++ b/km_docs/sample-curl-peoplesearchv3.bash
@@ -1,0 +1,7 @@
+curl -H "Content-Type: application/json" -X POST -d '{    "sort":"0",    "order":"asc",    "product_id":"YOUR_PRODUCT_ID",    "query_params": {      "type":"group",      "filter":{"type":"and", "operands":[{"type":"event","negate":false,"event":72,"frequencyValue":1,"frequencyOccurance":"at_least","comparisonMode":"any_value"}], "options": {"defaultDateRange":{"start_date":"2015-06-01","end_date":"2015-06-02"}}},      "defaultCalculationDateRange":{"dateRangeId":"custom","startDate":"2015-05-31T17:00:00-0700","endDate":"2015-06-01T17:00:00-0700"},      "calculations":[{"type":"first_date_in_range","subject":{"type":"event","negate":false,"event":6,"frequencyValue":1,"frequencyOccurance":"at_least","version":2,"options":{}},"label":"First time of visited site"}]    }  }' -H "Authorization: Bearer YOUR_API_TOKEN" -i "https://query.kissmetrics.com/v2/products/YOUR_PRODUCT_ID/reports/people_search"
+
+// Note the url needs to be extracted from the link returned above
+curl -H "Authorization: Bearer YOUR_API_TOKEN" -i https://query.kissmetrics.com/v2/queries/099cc7cc-7fda-4284-8412-b64bd7b01bdb/status
+
+// Note the url needs to be extracted from the results link returned above
+curl -H "Authorization: Bearer YOUR_API_TOKEN" -i https://query.kissmetrics.com/v2/queries/099cc7cc-7fda-4284-8412-b64bd7b01bdb/results

--- a/km_docs/sample-km-complicated-report-v3.json
+++ b/km_docs/sample-km-complicated-report-v3.json
@@ -1,0 +1,94 @@
+{
+  "sort": "0",
+  "order": "asc",
+  "product_id": "6581c29e-ab13-1030-97f2-22000a91b1a1",
+  "query_params": {
+    "type": "group",
+    "filter": {
+      "type": "then",
+      "operands": [{
+        "type": "or",
+        "operands": [{
+          "type": "event",
+          "negate": false,
+          "event": 2,
+          "frequencyValue": "7",
+          "frequencyOccurrence": "at_least",
+          "dateRange": {
+            "dateRangeId": "last_7_days"
+          },
+          "withProperty": true,
+          "property": 494,
+          "comparisonMode": "any_value"
+        }]
+      }, {
+        "type": "property",
+        "negate": false,
+        "property": 463,
+        "comparisonMode": "begins_with",
+        "comparisonString": "1",
+        "dateRange": {
+          "dateRangeId": "last_7_days"
+        }
+      }],
+      "dateRange": {
+        "dateRangeId": "last_7_days"
+      },
+      "version": 2,
+      "options": {
+        "defaultDateRange": "last_7_days"
+      }
+    },
+    "defaultCalculationDateRange": {
+      "dateRangeId": "last_7_days"
+    },
+    "calculations": [{
+      "type": "first_date_in_range",
+      "subject": {
+        "type": "event",
+        "negate": false,
+        "event": 243,
+        "frequencyValue": 1,
+        "frequencyOccurrence": "at_least",
+        "dateRange": {
+          "dateRangeId": "last_7_days"
+        },
+        "withProperty": true,
+        "property": "__channel",
+        "comparisonMode": "equals",
+        "comparisonString": "foo",
+        "version": 2,
+        "options": {
+          "defaultDateRange": {
+            "dateRangeId": "last_7_days"
+          }
+        }
+      },
+      "label": "First time of Account  imported page",
+      "date_range_label": "Last 7 days",
+      "start_date": 1465257600,
+      "end_date": 1465862399
+    }, {
+      "type": "first_value_in_range",
+      "subject": {
+        "type": "property",
+        "negate": false,
+        "property": "__channel",
+        "comparisonMode": "any_value",
+        "dateRange": {
+          "dateRangeId": "last_7_days"
+        },
+        "version": 2,
+        "options": {
+          "defaultDateRange": {
+            "dateRangeId": "last_7_days"
+          }
+        }
+      },
+      "label": "First value of Channel",
+      "date_range_label": "Last 7 days",
+      "start_date": 1465257600,
+      "end_date": 1465862399
+    }]
+  }
+}

--- a/km_docs/sample-km-signed-up-user-extract-v3.json
+++ b/km_docs/sample-km-signed-up-user-extract-v3.json
@@ -1,0 +1,191 @@
+{
+  "sort": "0",
+  "order": "asc",
+  "product_id": "6581c29e-ab13-1030-97f2-22000a91b1a1",
+  "query_params": {
+    "type": "group",
+    "filter": {
+      "type": "and",
+      "operands": [{
+        "type": "event",
+        "negate": false,
+        "event": 72,
+        "frequencyValue": 1,
+        "frequencyOccurrence": "at_least",
+        "dateRange": {
+          "dateRangeId": "custom",
+          "startDate": "2016-05-03",
+          "endDate": "2016-05-03"
+        },
+        "comparisonMode": "any_value"
+      }],
+      "dateRange": {
+        "dateRangeId": "this_month_to_date"
+      },
+      "version": 2,
+      "options": {
+        "defaultDateRange": {
+          "dateRangeId": "custom",
+          "startDate": "2016-05-03",
+          "endDate": "2016-05-03"
+        }
+      }
+    },
+    "calculations": [{
+      "type": "first_value_in_range",
+      "subject": {
+        "type": "property",
+        "negate": false,
+        "property": 0,
+        "comparisonMode": "any_value",
+        "dateRange": {
+          "dateRangeId": "any_time"
+        },
+        "version": 2,
+        "options": {
+          "defaultDateRange": {
+            "dateRangeId": "any_time"
+          }
+        }
+      },
+      "label": "First value of Customer ID",
+      "date_range_label": "Any time"
+    }, {
+      "type": "first_date_in_range",
+      "subject": {
+        "type": "event",
+        "negate": false,
+        "event": 6,
+        "frequencyValue": 1,
+        "frequencyOccurrence": "at_least",
+        "dateRange": {
+          "dateRangeId": "any_time"
+        },
+        "comparisonMode": "any_value",
+        "version": 2,
+        "options": {
+          "defaultDateRange": {
+            "dateRangeId": "any_time"
+          }
+        }
+      },
+      "label": "First time of Visited site",
+      "date_range_label": "Any time"
+    }, {
+      "type": "first_value_in_range",
+      "subject": {
+        "type": "property",
+        "negate": false,
+        "property": 7,
+        "comparisonMode": "any_value",
+        "dateRange": {
+          "dateRangeId": "any_time"
+        },
+        "version": 2,
+        "options": {
+          "defaultDateRange": {
+            "dateRangeId": "any_time"
+          }
+        }
+      },
+      "label": "First value of Campaign source",
+      "date_range_label": "Any time"
+    }, {
+      "type": "first_value_in_range",
+      "subject": {
+        "type": "property",
+        "negate": false,
+        "property": 5,
+        "comparisonMode": "any_value",
+        "dateRange": {
+          "dateRangeId": "any_time"
+        },
+        "version": 2,
+        "options": {
+          "defaultDateRange": {
+            "dateRangeId": "any_time"
+          }
+        }
+      },
+      "label": "First value of Campaign medium",
+      "date_range_label": "Any time"
+    }, {
+      "type": "first_value_in_range",
+      "subject": {
+        "type": "property",
+        "negate": false,
+        "property": 6,
+        "comparisonMode": "any_value",
+        "dateRange": {
+          "dateRangeId": "any_time"
+        },
+        "version": 2,
+        "options": {
+          "defaultDateRange": {
+            "dateRangeId": "any_time"
+          }
+        }
+      },
+      "label": "First value of Campaign name",
+      "date_range_label": "Any time"
+    }, {
+      "type": "first_value_in_range",
+      "subject": {
+        "type": "property",
+        "negate": false,
+        "property": 4,
+        "comparisonMode": "any_value",
+        "dateRange": {
+          "dateRangeId": "any_time"
+        },
+        "version": 2,
+        "options": {
+          "defaultDateRange": {
+            "dateRangeId": "any_time"
+          }
+        }
+      },
+      "label": "First value of Campaign content",
+      "date_range_label": "Any time"
+    }, {
+      "type": "first_value_in_range",
+      "subject": {
+        "type": "property",
+        "negate": false,
+        "property": 8,
+        "comparisonMode": "any_value",
+        "dateRange": {
+          "dateRangeId": "any_time"
+        },
+        "version": 2,
+        "options": {
+          "defaultDateRange": {
+            "dateRangeId": "any_time"
+          }
+        }
+      },
+      "label": "First value of Campaign terms",
+      "date_range_label": "Any time"
+    }, {
+      "type": "first_value_in_range",
+      "subject": {
+        "type": "property",
+        "negate": false,
+        "property": 1,
+        "comparisonMode": "any_value",
+        "dateRange": {
+          "dateRangeId": "any_time"
+        },
+        "version": 2,
+        "options": {
+          "defaultDateRange": {
+            "dateRangeId": "any_time"
+          }
+        }
+      },
+      "label": "First value of Referrer",
+      "date_range_label": "Any time"
+    }],
+    "defaultCalculationDateRange": "any_time"
+  }
+}

--- a/km_docs/sample-km-simple-report-v3.json
+++ b/km_docs/sample-km-simple-report-v3.json
@@ -1,0 +1,191 @@
+{
+  "sort": "0",
+  "order": "asc",
+  "product_id": "6581c29e-ab13-1030-97f2-22000a91b1a1",
+  "query_params": {
+    "type": "group",
+    "filter": {
+      "type": "and",
+      "operands": [{
+        "type": "event",
+        "negate": false,
+        "event": 72,
+        "frequencyValue": 1,
+        "frequencyOccurrence": "at_least",
+        "dateRange": {
+          "dateRangeId": "custom",
+          "startDate": "2016-05-03",
+          "endDate": "2016-05-03"
+        },
+        "comparisonMode": "any_value"
+      }],
+      "dateRange": {
+        "dateRangeId": "this_month_to_date"
+      },
+      "version": 2,
+      "options": {
+        "defaultDateRange": {
+          "dateRangeId": "custom",
+          "startDate": "2016-05-03",
+          "endDate": "2016-05-03"
+        }
+      }
+    },
+    "calculations": [{
+      "type": "first_value_in_range",
+      "subject": {
+        "type": "property",
+        "negate": false,
+        "property": 0,
+        "comparisonMode": "any_value",
+        "dateRange": {
+          "dateRangeId": "any_time"
+        },
+        "version": 2,
+        "options": {
+          "defaultDateRange": {
+            "dateRangeId": "any_time"
+          }
+        }
+      },
+      "label": "First value of Customer ID",
+      "date_range_label": "Any time"
+    }, {
+      "type": "first_date_in_range",
+      "subject": {
+        "type": "event",
+        "negate": false,
+        "event": 6,
+        "frequencyValue": 1,
+        "frequencyOccurrence": "at_least",
+        "dateRange": {
+          "dateRangeId": "any_time"
+        },
+        "comparisonMode": "any_value",
+        "version": 2,
+        "options": {
+          "defaultDateRange": {
+            "dateRangeId": "any_time"
+          }
+        }
+      },
+      "label": "First time of Visited site",
+      "date_range_label": "Any time"
+    }, {
+      "type": "first_value_in_range",
+      "subject": {
+        "type": "property",
+        "negate": false,
+        "property": 7,
+        "comparisonMode": "any_value",
+        "dateRange": {
+          "dateRangeId": "any_time"
+        },
+        "version": 2,
+        "options": {
+          "defaultDateRange": {
+            "dateRangeId": "any_time"
+          }
+        }
+      },
+      "label": "First value of Campaign source",
+      "date_range_label": "Any time"
+    }, {
+      "type": "first_value_in_range",
+      "subject": {
+        "type": "property",
+        "negate": false,
+        "property": 5,
+        "comparisonMode": "any_value",
+        "dateRange": {
+          "dateRangeId": "any_time"
+        },
+        "version": 2,
+        "options": {
+          "defaultDateRange": {
+            "dateRangeId": "any_time"
+          }
+        }
+      },
+      "label": "First value of Campaign medium",
+      "date_range_label": "Any time"
+    }, {
+      "type": "first_value_in_range",
+      "subject": {
+        "type": "property",
+        "negate": false,
+        "property": 6,
+        "comparisonMode": "any_value",
+        "dateRange": {
+          "dateRangeId": "any_time"
+        },
+        "version": 2,
+        "options": {
+          "defaultDateRange": {
+            "dateRangeId": "any_time"
+          }
+        }
+      },
+      "label": "First value of Campaign name",
+      "date_range_label": "Any time"
+    }, {
+      "type": "first_value_in_range",
+      "subject": {
+        "type": "property",
+        "negate": false,
+        "property": 4,
+        "comparisonMode": "any_value",
+        "dateRange": {
+          "dateRangeId": "any_time"
+        },
+        "version": 2,
+        "options": {
+          "defaultDateRange": {
+            "dateRangeId": "any_time"
+          }
+        }
+      },
+      "label": "First value of Campaign content",
+      "date_range_label": "Any time"
+    }, {
+      "type": "first_value_in_range",
+      "subject": {
+        "type": "property",
+        "negate": false,
+        "property": 8,
+        "comparisonMode": "any_value",
+        "dateRange": {
+          "dateRangeId": "any_time"
+        },
+        "version": 2,
+        "options": {
+          "defaultDateRange": {
+            "dateRangeId": "any_time"
+          }
+        }
+      },
+      "label": "First value of Campaign terms",
+      "date_range_label": "Any time"
+    }, {
+      "type": "first_value_in_range",
+      "subject": {
+        "type": "property",
+        "negate": false,
+        "property": 1,
+        "comparisonMode": "any_value",
+        "dateRange": {
+          "dateRangeId": "any_time"
+        },
+        "version": 2,
+        "options": {
+          "defaultDateRange": {
+            "dateRangeId": "any_time"
+          }
+        }
+      },
+      "label": "First value of Referrer",
+      "date_range_label": "Any time"
+    }],
+    "defaultCalculationDateRange": "any_time"
+  }
+}

--- a/km_docs/sample-people-search-3-payload.json
+++ b/km_docs/sample-people-search-3-payload.json
@@ -1,0 +1,139 @@
+{
+  "sort": "0",
+  "order": "asc",
+  "product_id": "6581c29e-ab13-1030-97f2-22000a91b1a1",
+  "query_params": {
+    "type": "group",
+    "filter": {
+      "type": "and",
+      "operands": [{
+        "type": "property",
+        "negate": false,
+        "property": 7,
+        "comparisonMode": "any_value",
+        "dateRange": {
+          "dateRangeId": "custom",
+          "startDate": "2016-05-09",
+          "endDate": "2016-05-09"
+        }
+      }],
+      "dateRange": {
+        "dateRangeId": "last_7_days"
+      },
+      "version": 2,
+      "options": {
+        "defaultDateRange": {
+          "dateRangeId": "custom",
+          "startDate": "2016-05-09",
+          "endDate": "2016-05-09"
+        }
+      }
+    },
+    "defaultCalculationDateRange": {
+      "dateRangeId": "custom",
+      "startDate": "2016-04-09",
+      "endDate": "2016-05-09"
+    },
+    "calculations": [{
+      "type": "first_date_in_range",
+      "subject": {
+        "type": "property",
+        "negate": false,
+        "property": 7,
+        "comparisonMode": "any_value",
+        "dateRange": {
+          "dateRangeId": "custom",
+          "startDate": "2016-05-09",
+          "endDate": "2016-05-09"
+        },
+        "version": 2,
+        "options": {
+          "defaultDateRange": {
+            "dateRangeId": "custom",
+            "startDate": "2016-05-09",
+            "endDate": "2016-05-09"
+          }
+        }
+      },
+      "label": "First time of Campaign source",
+      "date_range_label": "May 9",
+      "start_date": 1462752000,
+      "end_date": 1462838399
+    }, {
+      "type": "first_value_in_range",
+      "subject": {
+        "type": "property",
+        "negate": false,
+        "property": 7,
+        "comparisonMode": "any_value",
+        "dateRange": {
+          "dateRangeId": "custom",
+          "startDate": "2016-04-09",
+          "endDate": "2016-05-09"
+        },
+        "version": 2,
+        "options": {
+          "defaultDateRange": {
+            "dateRangeId": "custom",
+            "startDate": "2016-04-09",
+            "endDate": "2016-05-09"
+          }
+        }
+      },
+      "label": "First value of Campaign source",
+      "date_range_label": "Apr 9 - May 9",
+      "start_date": 1460160000,
+      "end_date": 1462838399
+    }, {
+      "type": "last_date_in_range",
+      "subject": {
+        "type": "property",
+        "negate": false,
+        "property": 7,
+        "comparisonMode": "any_value",
+        "dateRange": {
+          "dateRangeId": "custom",
+          "startDate": "2016-05-09",
+          "endDate": "2016-05-09"
+        },
+        "version": 2,
+        "options": {
+          "defaultDateRange": {
+            "dateRangeId": "custom",
+            "startDate": "2016-05-09",
+            "endDate": "2016-05-09"
+          }
+        }
+      },
+      "label": "Last time of Campaign source",
+      "date_range_label": "May 9",
+      "start_date": 1462752000,
+      "end_date": 1462838399
+    }, {
+      "type": "last_value_in_range",
+      "subject": {
+        "type": "property",
+        "negate": false,
+        "property": 7,
+        "comparisonMode": "any_value",
+        "dateRange": {
+          "dateRangeId": "custom",
+          "startDate": "2016-05-09",
+          "endDate": "2016-05-09"
+        },
+        "version": 2,
+        "options": {
+          "defaultDateRange": {
+            "dateRangeId": "custom",
+            "startDate": "2016-05-09",
+            "endDate": "2016-05-09"
+          }
+        }
+      },
+      "label": "Last value of Campaign source",
+      "date_range_label": "May 9",
+      "start_date": 1462752000,
+      "end_date": 1462838399
+    }]
+  }
+}


### PR DESCRIPTION
Updating Kissr to work with the new People Search v3 API offered by kiss metrics. This requires a whole scale rewrite of the Kissr internals but the end result is a much more powerful system. We now provide the capability of building your own reports directly from Kissr rather than having to build them within the KM interface. Generating a report does require more apriori knowledge of the interface and your KM events and properties, but we've found the increased capability to be well worth it.

BI-1101 Fix report so it still works when reports is list and not matrix.

BI-1101 Create function that checks is 'identity' and 'columns' fields are present. Add file for testing, which will be deleted before merge.

Building out the interface for the new people_search_v3 report generation system. We can now generate json for the report target segment by using a combination of rules properties. Still need to test much of the edge cases and build out the columns. Also need to provide a mechanism for accessing KM events and properties to get their ids

Got options working for KissSegment and asJson. Also added some sample json files and bash files for testingand KM api reference

Think I have the basics of generating a report request json down. There are a lot of extras missing, and still need to do a lot of testing, but the heavy lifting is complete now

It actually submits the request and brings back data now! We have to do a bunch of work to get the columns labeled appropriately, and we don't expose most of the functionality available in the new KM api, and the documentation is poor, and the code needs a clean up pass. But we actually request a report from KM and it returns data (although we don't parse the data properly any more).

Automagically convert date based calculations from epoch timestamps to POSIXct datetimes

Added documentation for asJson - started docs for KissCalculation

BI-1101 Create functions to 1) pull full list of KM events 2) pull full list of KM properties and 3) pull the idex of a single property or event for use in kiss-report function.

Fixing documentation, cleaning up code, incremented version to 1.0.0.0

Fixed a typo in examples. Added documentation for asJson and names.KissReport

Fixed 2 bugs having to do with properties - KissCalculation.Property had the wrong type set, that's fixed now. And KissRule.Property needed to support a ComparisonString for specific ComparisonModes. Also fixed

Prettified json file

BI-1101 Insert date range into KissRule.Event and KissRule.Property, and correct asJson.KissRule to use date range when interval is fed to these functions.

Some minor code fixes for intervals with KissRules

Fixed a bug in kiss rule asJson (missing comma). Switched the time conversion to use dplyr to fix a warning about multiple assignment

BI-1101 Fix asJson function for Property attrbutes

update bash example so we aren't leaking API keys. Updated examples for KissRule.property

Handle empty reports
